### PR TITLE
Support both 2.gum.fm and s.gum.fm

### DIFF
--- a/src/prefixes.json
+++ b/src/prefixes.json
@@ -66,7 +66,7 @@
         "notes": ""
     },
     {
-        "prefixpattern": "2.gum.fm",
+        "prefixpattern": ".gum.fm",
         "prefixname": "Gumshoe",
         "iab": "0",
         "abilities_stats": "0",


### PR DESCRIPTION
Gumball has a new prefix URL: `s.gum.fm/s-{SHOW_ID}/`, where SHOW_ID is a 24 character string. 
It should gradually replace `2.gum.fm`